### PR TITLE
Overloads for storing and retrieving JSON-serializable objects

### DIFF
--- a/Storage.cs
+++ b/Storage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2018 cloudcrate solutions UG (haftungsbeschraenkt)
 
+using Microsoft.AspNetCore.Blazor;
 using Microsoft.AspNetCore.Blazor.Browser.Interop;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -27,6 +28,12 @@ namespace Cloudcrate.AspNetCore.Blazor.Browser.Storage
             return RegisteredFunction.Invoke<string>($"{_fullTypeName}.GetItem", key);
         }
 
+        public T GetItem<T>(string key)
+        {
+            var json = GetItem(key);
+            return string.IsNullOrEmpty(json) ? default(T) : JsonUtil.Deserialize<T>(json);
+        }
+
         public string Key(int index)
         {
             return RegisteredFunction.Invoke<string>($"{_fullTypeName}.Key", index);
@@ -48,6 +55,11 @@ namespace Cloudcrate.AspNetCore.Blazor.Browser.Storage
         public void SetItem(string key, string data)
         {
             RegisteredFunction.Invoke<object>($"{_fullTypeName}.SetItem", key, data);
+        }
+
+        public void SetItem(string key, object data)
+        {
+            SetItem(key, JsonUtil.Serialize(data));
         }
 
         public string this[string key]


### PR DESCRIPTION
This package is great!

I've just been using it for a small project and found that in basically all cases I wanted to store and retrieve JSON-serialized objects.

This PR is a suggestion to add a simple and convenient way of doing that. It doesn't prevent people from still calling the `string` overloads that allow exact control over the representation of the stored data.