### PR TITLE
avoid adding multiple instances in DI

### DIFF
--- a/Cloudcrate.AspNetCore.Blazor.Browser.Storage.csproj
+++ b/Cloudcrate.AspNetCore.Blazor.Browser.Storage.csproj
@@ -38,9 +38,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.5.0-preview1-t000" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.5.0-preview1-t000" />
-    <PackageReference Include="Microsoft.JSInterop" Version="0.5.0-preview1-t000" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.5.0-preview1-10351" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.5.0-preview1-10351" />
+    <PackageReference Include="Microsoft.JSInterop" Version="0.5.0-preview1-10351" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Storage.cs
+++ b/Storage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2018 cloudcrate solutions UG (haftungsbeschraenkt)
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.JSInterop;
 
 namespace Cloudcrate.AspNetCore.Blazor.Browser.Storage
@@ -79,8 +80,8 @@ namespace Cloudcrate.AspNetCore.Blazor.Browser.Storage
     {
         public static void AddStorage(this IServiceCollection col)
         {
-            col.AddSingleton<LocalStorage>();
-            col.AddSingleton<SessionStorage>();
+            col.TryAdd(ServiceDescriptor.Singleton<LocalStorage, LocalStorage>());
+            col.TryAdd(ServiceDescriptor.Singleton<SessionStorage, SessionStorage>());
         }
     }
 }


### PR DESCRIPTION
Hi and thanks for your library.

I was experimenting with it for a library of my own and i started wondering what would happen to an user registering both my library and yours: would the DI complain about the double registration? Apparently it does not but the services collection count increases by two when i register both my and your library (probably the duplication is resolved during the DI system build and, yes, I should study this topic a lot more).

Anyway, as a quick fix, I changed the AddSingleton calls with the TryAdd counterparts and... It works on my pc! :smile:

Oh, I also updated the nuget dependencies version because I wasn't able to install the original versions.

Thanks again for your library, it works like a charm!

Ciao